### PR TITLE
KT1-120: 임베딩 모델 text-embedding-3-large로 변경 및 차원 축소 적용

### DIFF
--- a/app/core/llm_service.py
+++ b/app/core/llm_service.py
@@ -11,18 +11,22 @@ from app.config.config import Config
 OPENAI_API_KEY = Config.OPENAI_API_KEY
 STORY_SERVICE_URL = "http://localhost:8011" # 스토리 서비스 URL (현재 개발 중, 추후 API 호출 가능하다고 가정)
 
-async def get_embedding(text: str) -> List[float]:
+async def get_embedding(text: str, dimensions: int = 1024) -> List[float]:
     """
     OpenAI Embeddings API를 호출하여 텍스트의 임베딩 벡터를 반환합니다.
+    MRL(Matryoshka Representation Learning)을 활용하여 임베딩 차원을 조절할 수 있습니다.
     """
     if not OPENAI_API_KEY:
         raise ValueError("OPENAI_API_KEY 환경 변수가 설정되지 않았습니다.")
 
     client = OpenAI(api_key=OPENAI_API_KEY)
+    model = "text-embedding-3-large"
     try:
+        print(f"Creating embedding with model: {model} and dimensions: {dimensions}")
         response = client.embeddings.create(
             input=text,
-            model="text-embedding-3-small"
+            model=model,
+            dimensions=dimensions
         )
         return response.data[0].embedding
     except Exception as e:

--- a/app/helper/question_helper.py
+++ b/app/helper/question_helper.py
@@ -167,11 +167,11 @@ async def upload_and_save_voice_answer(
     if text_content and question_id:
         question = db.query(models.Question).filter(models.Question.id == question_id).first()
         if question and question.expected_answers:
-            user_answer_embedding = await get_embedding(text_content)
+            user_answer_embedding = await get_embedding(text_content, dimensions=1024)
             if user_answer_embedding:
                 max_similarity = 0.0
                 for expected_ans in question.expected_answers:
-                    expected_ans_embedding = await get_embedding(expected_ans)
+                    expected_ans_embedding = await get_embedding(expected_ans, dimensions=1024)
                     if expected_ans_embedding:
                         similarity = cosine_similarity(user_answer_embedding, expected_ans_embedding)
                         if similarity > max_similarity:


### PR DESCRIPTION
- get_embedding 함수에서 사용되는 임베딩 모델을 기존 text-embedding-3-small에서 text-embedding-3-large로 변경
- Matryoshka Representation Learning (MRL) 기술을 활용하여 임베딩 차원을 1024로 축소 적용
- 모델 변경에 따른 성능 변화를 측정하고, 비교 문서를 작성하여 추후 개선을 위한 기반 마련