### PR TITLE
KT1-131: feat(daily-question-service): 주간 답변 조회 기능 및 CRUD 로직 분리\n\n- …

### DIFF
--- a/app/api/question_router.py
+++ b/app/api/question_router.py
@@ -1,14 +1,14 @@
-import os
-import httpx
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Form
 from sqlalchemy.orm import Session
 from typing import List, Optional
+import datetime
 
 from app.schemas import question_schema
 from app.utils.db import get_db
 from app.config.config import Config
 from app.helper import question_helper
 from app.core.s3_service import S3Service
+from app.core import crud_service # crud_service 임포트 추가
 
 router = APIRouter(
     prefix="/questions",
@@ -24,48 +24,53 @@ async def get_daily_question(user_id: int, db: Session = Depends(get_db)):
 
 @router.post("/", response_model=question_schema.Question)
 def create_question(question: question_schema.QuestionCreate, db: Session = Depends(get_db)):
-    return question_helper.create_question(db=db, question=question)
+    return crud_service.create_question(db=db, question=question) # crud_service로 변경
 
 @router.get("/", response_model=List[question_schema.Question])
 def read_questions(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
-    return question_helper.read_questions(db=db, skip=skip, limit=limit)
+    return crud_service.read_questions(db=db, skip=skip, limit=limit) # crud_service로 변경
 
 @router.get("/answers", response_model=List[question_schema.Answer])
-def get_answers_by_user(user_id: int, db: Session = Depends(get_db)):
-    answers = question_helper.get_answers_by_user(db=db, user_id=user_id)
+def get_answers_by_user(
+    user_id: int,
+    start_date: Optional[datetime.datetime] = None,
+    end_date: Optional[datetime.datetime] = None,
+    db: Session = Depends(get_db)
+):
+    answers = crud_service.get_answers_by_user(db=db, user_id=user_id, start_date=start_date, end_date=end_date) # crud_service로 변경
     return answers
 
 @router.get("/{question_id}", response_model=question_schema.Question)
 def read_question(question_id: int, db: Session = Depends(get_db)):
-    question = question_helper.read_question(db=db, question_id=question_id)
+    question = crud_service.read_question(db=db, question_id=question_id) # crud_service로 변경
     if question is None:
         raise HTTPException(status_code=404, detail="Question not found")
     return question
 
 @router.put("/{question_id}", response_model=question_schema.Question)
 def update_question(question_id: int, question: question_schema.QuestionCreate, db: Session = Depends(get_db)):
-    db_question = question_helper.update_question(db=db, question_id=question_id, question=question)
+    db_question = crud_service.update_question(db=db, question_id=question_id, question=question) # crud_service로 변경
     if db_question is None:
         raise HTTPException(status_code=404, detail="Question not found")
     return db_question
 
 @router.delete("/{question_id}", response_model=question_schema.Question)
 def delete_question(question_id: int, db: Session = Depends(get_db)):
-    db_question = question_helper.delete_question(db=db, question_id=question_id)
+    db_question = crud_service.delete_question(db=db, question_id=question_id) # crud_service로 변경
     if db_question is None:
         raise HTTPException(status_code=404, detail="Question not found")
     return db_question
 
 @router.get("/answers/{answer_id}", response_model=question_schema.Answer)
 def get_answer_by_id(answer_id: int, db: Session = Depends(get_db)):
-    answer = question_helper.get_answer_by_id(db=db, answer_id=answer_id)
+    answer = crud_service.get_answer_by_id(db=db, answer_id=answer_id) # crud_service로 변경
     if answer is None:
         raise HTTPException(status_code=404, detail="Answer not found")
     return answer
 
 @router.delete("/answers/{answer_id}", response_model=question_schema.Answer)
 def delete_answer(answer_id: int, db: Session = Depends(get_db)):
-    db_answer = question_helper.delete_answer(db=db, answer_id=answer_id)
+    db_answer = crud_service.delete_answer(db=db, answer_id=answer_id) # crud_service로 변경
     if db_answer is None:
         raise HTTPException(status_code=404, detail="Answer not found")
     return db_answer

--- a/app/core/crud_service.py
+++ b/app/core/crud_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from typing import List, Optional
+import datetime
 
 from app import models, schemas
 
@@ -49,8 +50,18 @@ def create_answer_db(db: Session, answer: schemas.AnswerCreate): # Renamed to av
     db.refresh(db_answer)
     return db_answer
 
-def get_answers_by_user(db: Session, user_id: int) -> List[schemas.Answer]:
-    return db.query(models.Answer).filter(models.Answer.user_id == user_id).all()
+def get_answers_by_user(
+    db: Session,
+    user_id: int,
+    start_date: Optional[datetime.datetime] = None,
+    end_date: Optional[datetime.datetime] = None
+) -> List[schemas.Answer]:
+    query = db.query(models.Answer).filter(models.Answer.user_id == user_id)
+    if start_date:
+        query = query.filter(models.Answer.created_at >= start_date)
+    if end_date:
+        query = query.filter(models.Answer.created_at <= end_date)
+    return query.all()
 
 def get_answer_by_id(db: Session, answer_id: int) -> Optional[schemas.Answer]:
     return db.query(models.Answer).filter(models.Answer.id == answer_id).first()


### PR DESCRIPTION
…app/api/question_router.py:\n    - 기존 question_helper에서 처리하던 CRUD 로직을 app.core.crud_service로 이관.\n    - get_answers_by_user 엔드포인트에 start_date 및 end_date 쿼리 파라미터 추가.\n- app/core/crud_service.py:\n    - get_answers_by_user 함수에 start_date 및 end_date를 이용한 날짜 필터링 로직 구현.\n    - datetime 모듈 임포트 추가.\n\n이 변경 사항은 notification-service의 주간 보고서 생성 기능에 필요한 특정 기간 동안의 사용자 답변 조회 기능을 제공하며, 코드의 모듈성을 향상시킵니다.